### PR TITLE
Update parameter name for naming consistency and slightly better clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1153,7 +1153,7 @@ console.log(data);
 #### Endpoint
 
 ```sh
-/api/v2/hianime/episode/servers?animeEpisodeId={id}
+/api/v2/hianime/episode/servers?animeEpisodeId={animeEpisodeId}
 ```
 
 #### Query Parameters


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file. The change updates the query parameter name in the endpoint example for slightly better clarity.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1156-R1156): Updated the query parameter from `{id}` to `{animeEpisodeId}` in the endpoint example.