### PR TITLE
build: install curl for healthcheck in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ LABEL org.opencontainers.image.source=https://github.com/ghoshRitesh12/aniwatch-
 LABEL org.opencontainers.image.description="Node.js API for obtaining anime information from hianime.to"
 LABEL org.opencontainers.image.licenses=MIT
 
+# install curl for healthcheck
+RUN apk add --no-cache curl
+
 # create a non-privileged user
 RUN addgroup -S aniwatch && adduser -S zoro -G aniwatch
 


### PR DESCRIPTION
Issue: Previously, healthcheck fails due to not having curl installed in the container, even though the `/heath` endpoint is working fine and returning 200 OK. This makes the container show up as "unhealthy" even though it was working perfectly fine.

![image](https://github.com/user-attachments/assets/372c5204-e08d-4fd4-8851-d4a92158d55b)

This pull request includes a small change to the `Dockerfile`. The change installs `curl` for health checks.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R23-R25): Added a command to install `curl` for health checks.