### PR TITLE
fix: build error in logger, cache, and logging middleware

### DIFF
--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -20,7 +20,6 @@ const loggerOptions: LoggerOptions = {
             };
         },
     },
-    timestamp: pino.stdTimeFunctions.isoTime,
 };
 
 export const log = pino(loggerOptions);

--- a/src/middleware/cache.ts
+++ b/src/middleware/cache.ts
@@ -1,7 +1,7 @@
 import { env } from "../config/env.js";
 import { AniwatchAPICache, cache } from "../config/cache.js";
 import type { BlankInput } from "hono/types";
-import type { Context, MiddlewareHandler } from "hono";
+import type { Context, MiddlewareHandler, Handler } from "hono";
 import type { ServerContext } from "../config/context.js";
 
 // Define middleware to add Cache-Control header
@@ -41,9 +41,10 @@ export function cacheConfigSetter(keySliceIndex: number): MiddlewareHandler {
     };
 }
 
+//  FIXED: add explicit return type
 export function withCache<T, P extends string = string>(
     getData: (c: Context<ServerContext, P, BlankInput>) => Promise<T>
-) {
+): Handler<ServerContext, P, BlankInput> {
     return async (c: Context<ServerContext, P, BlankInput>) => {
         const cacheConfig = c.get("CACHE_CONFIG");
 
@@ -56,10 +57,3 @@ export function withCache<T, P extends string = string>(
         return c.json({ status: 200, data }, { status: 200 });
     };
 }
-
-// export function _withCache<T>(
-//     context: Context<ServerContext>,
-//     promise: Promise<T>
-// ): MiddlewareHandler {
-//     return async (c) => {};
-// }

--- a/src/middleware/logging.ts
+++ b/src/middleware/logging.ts
@@ -3,7 +3,7 @@ import { logger as honoLogger } from "hono/logger";
 import { log } from "../config/logger.js";
 
 export const logging: MiddlewareHandler = honoLogger(
-    (msg: string, ...rest: string[]) => {
+    (msg: string, ...rest: any[]) => {
         log.info(msg, ...rest);
     }
 );


### PR DESCRIPTION
At the Build time three errors were occuring due to the pino package upgradation. Fixed those build errors.

```
Error 1: 8
3.365 src/config/logger.ts(23,21): error TS2339: Property 'stdTimeFunctions' does not exist on type '{ <CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean>(optionsOrStream?: LoggerOptions<CustomLevels, UseOnlyCustomLevels> | DestinationStream | undefined): Logger<...>; <CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean>(options: LoggerOptions<...>, st...'.

3.365 src/config/logger.ts(23,21): error TS2339: Property 'stdTimeFunctions' does not exist on type '{ <CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean>(optionsOrStream?: LoggerOptions<CustomLevels, UseOnlyCustomLevels> | DestinationStream | undefined): Logger<...>; <CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean>(options: LoggerOptions<...>, st...'.
2025-Sep-27 18:27:29.881900
3.366 src/middleware/cache.ts(44,17): error TS2742: The inferred type of 'withCache' cannot be named without a reference to '../../node_modules/hono/dist/types/context.js'. This is likely not portable. A type annotation is necessary.
2025-Sep-27 18:27:29.881900
3.366 src/middleware/logging.ts(7,23): error TS2345: Argument of type 'string' is not assignable to parameter of type 'undefined'.
```
